### PR TITLE
Update to latest SHA256 hash

### DIFF
--- a/Formula/ytarchive.rb
+++ b/Formula/ytarchive.rb
@@ -3,7 +3,7 @@ class Ytarchive < Formula
   homepage "https://github.com/Kethsar/ytarchive"
   url "https://github.com/Kethsar/ytarchive/archive/refs/tags/latest.tar.gz"
   version "0.3.1"
-  sha256 "f61ac9b3606476306c208dd87961a3ca846efa92eaad651fa0270293c13a54c2"
+  sha256 "8075ddb116f9a7e861fd7b318dfce3277dbebbdc8a8c2fcdf8f025d98c9a26a8"
   license "MIT"
   head "https://github.com/Kethsar/ytarchive.git", branch: "master"
 

--- a/Formula/ytarchive.rb
+++ b/Formula/ytarchive.rb
@@ -2,7 +2,7 @@ class Ytarchive < Formula
   desc "Archive live and upcoming Youtube.com live streams"
   homepage "https://github.com/Kethsar/ytarchive"
   url "https://github.com/Kethsar/ytarchive/archive/refs/tags/latest.tar.gz"
-  version "0.3.1"
+  version "0.3.2"
   sha256 "8075ddb116f9a7e861fd7b318dfce3277dbebbdc8a8c2fcdf8f025d98c9a26a8"
   license "MIT"
   head "https://github.com/Kethsar/ytarchive.git", branch: "master"


### PR DESCRIPTION
Fixes the install error with the mismatching SHA256 hash.